### PR TITLE
Force uppercase on first character

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,10 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0-alpha1'
+        classpath 'com.android.tools.build:gradle:3.1.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
@@ -16,6 +17,7 @@ allprojects {
     repositories {
         jcenter()
         maven { url "https://jitpack.io" }
+        google()
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 26 19:56:39 CEST 2016
+#Thu Dec 05 22:00:22 CET 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/module/build.gradle
+++ b/module/build.gradle
@@ -24,5 +24,5 @@ dependencies {
     compile 'com.android.support:design:23.4.0'
     compile 'com.android.support:support-annotations:23.4.0'
     compile 'com.android.support:recyclerview-v7:23.4.0'
-    compile 'com.amulyakhare:com.amulyakhare.textdrawable:1.0.1'
+    compile 'com.github.amulyakhare:TextDrawable:master'
 }

--- a/module/src/main/java/com/touchboarder/weekdaysbuttons/WeekdaysDataSource.java
+++ b/module/src/main/java/com/touchboarder/weekdaysbuttons/WeekdaysDataSource.java
@@ -649,12 +649,15 @@ public class WeekdaysDataSource implements Parcelable {
         if (subStringLength > mNumberOfLetters)
             subStringLength = mNumberOfLetters;
 
+        String abbr = label.substring(0, subStringLength);
+        abbr = abbr.substring(0, 1).toUpperCase() + abbr.substring(1);
+
         Drawable drawable = null;
         if (textDrawableCallback != null)
-            drawable = textDrawableCallback.onDrawTextDrawable(mAttachId, calendarDayId, label.substring(0, subStringLength), selected);
+            drawable = textDrawableCallback.onDrawTextDrawable(mAttachId, calendarDayId, abbr, selected);
 
         if (drawable == null && getDrawableProvider() != null)
-            drawable = getDrawableProvider().getDrawableFromType(mContext, textDrawableType, label.substring(0, subStringLength), selected);
+            drawable = getDrawableProvider().getDrawableFromType(mContext, textDrawableType, abbr, selected);
         return drawable;
     }
 


### PR DESCRIPTION
For some locales (for example, Italian) weekdays start with a lowercase letter. Lowercase letters are ugly when used in your picker. This fixes it by forcing uppercase on the first letter, so making all locales behave the same.

![device-2017-04-08-191424](https://cloud.githubusercontent.com/assets/245615/24830950/20124c6e-1c90-11e7-869f-a9f3ce10c058.png)
